### PR TITLE
Update InviteAction.php

### DIFF
--- a/src/Actions/InviteAction.php
+++ b/src/Actions/InviteAction.php
@@ -4,6 +4,7 @@ namespace Tapp\FilamentInvite\Actions;
 
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\CanCustomizeProcess;
+use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Password;
@@ -37,7 +38,7 @@ class InviteAction extends Action
 
         $this->action(function (): void {
             $result = $this->process(static function (Model $user) {
-                $token = Password::broker()->createToken($user);
+                $token = Password::broker(Filament::getAuthPasswordBroker())->createToken($user);
 
                 // Use the method if the developer has specified one
                 if (method_exists($user, 'sendPasswordSetNotification')) {


### PR DESCRIPTION
I pass Filament::getAuthPasswordBroker() to Password::broker() so the reset token is issued through the same password-broker configuration that Filament uses for its admin guard. This guarantees that the token is stored, validated, and later consumed in the correct context for Filament users rather than the default Laravel user broker.