### PR TITLE
feat: add flexible routing system for invitation notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,34 @@ Invite action outside of a table uses a different class
 
 ```
 
+## Notification Routing
+
+The package uses a simple routing strategy for password reset URLs in invitation emails:
+
+- **Default**: If `filament-invite.routes.reset` config is empty, uses Filament's default routing
+- **Custom**: If a route name is configured, uses the specified custom route
+
+```php
+if (empty(config('filament-invite.routes.reset'))) {
+    $url = Filament::getResetPasswordUrl($this->token, $email, ['invite' => true]);
+} else {
+    $domain = rtrim(Filament::getPanel($this->filamentPanelId)->getPath(), '/');
+    $url = url($domain . '/' . route(config('filament-invite.routes.reset'), [
+        'token' => $this->token,
+        'email' => $email,
+        'invite' => true,
+    ], false));
+}
+```
+
+To use custom routing, set your route name in the config:
+
+```php
+'routes' => [
+    'reset' => 'your.custom.route.name',
+],
+```
+
 ## Customization
 
 ### Reset URL

--- a/README.md
+++ b/README.md
@@ -70,31 +70,111 @@ Invite action outside of a table uses a different class
 
 ## Notification Routing
 
-The package uses a simple routing strategy for password reset URLs in invitation emails:
+The password reset URL can be customized or use the Filament's authentication system:
 
-- **Default**: If `filament-invite.routes.reset` config is empty, uses Filament's default routing
-- **Custom**: If a route name is configured, uses the specified custom route
+- **Default**: Uses Filament's built-in routing (respects panel's `passwordResetRouteSlug` configuration)
+- **Custom**: Uses completely custom routes outside Filament's authentication system
 
 ```php
+// Get the appropriate panel
+$panel = $this->filamentPanelId
+    ? Filament::getPanel($this->filamentPanelId)
+    : Filament::getDefaultPanel();
+
 if (empty(config('filament-invite.routes.reset'))) {
-    $url = Filament::getResetPasswordUrl($this->token, $email, ['invite' => true]);
+    // Use Filament's built-in routing (respects panel's passwordResetRouteSlug configuration)
+    $url = $panel->getResetPasswordUrl($this->token, $notifiable, ['invite' => true]);
 } else {
-    $domain = rtrim(Filament::getPanel($this->filamentPanelId)->getPath(), '/');
-    $url = url($domain . '/' . route(config('filament-invite.routes.reset'), [
-        'token' => $this->token,
-        'email' => $email,
-        'invite' => true,
-    ], false));
+    // Support both custom routes and full URLs for maximum flexibility
+    $customRoute = config('filament-invite.routes.reset');
+
+    // Check if it's a full URL (starts with http/https)
+    if (str_starts_with($customRoute, 'http')) {
+        // Use the full URL directly
+        $url = $customRoute . '?' . http_build_query([
+            'token' => $this->token,
+            'email' => $email,
+            'invite' => true,
+        ]);
+    } else {
+        // Use as route name - determine base URL based on configuration
+        $routeUrl = route($customRoute, [
+            'token' => $this->token,
+            'email' => $email,
+            'invite' => true,
+        ], false);
+
+        // Choose base URL: panel URL or app.url (for backward compatibility)
+        $usePanelUrl = config('filament-invite.use_panel_url', false);
+        $baseUrl = $usePanelUrl ? $panel->getUrl() : config('app.url');
+
+        $url = rtrim($baseUrl, '/') . '/' . ltrim($routeUrl, '/');
+    }
 }
 ```
 
-To use custom routing, set your route name in the config:
+### Integration with Filament Panel Configuration
+
+When using the default routing, the package automatically respects your panel's authentication configuration:
+
+```php
+// In your panel configuration
+use Filament\Panel;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ->passwordResetRouteSlug('custom-reset') // This will be used automatically
+        ->passwordResetRequestRouteSlug('custom-request');
+}
+```
+
+To use custom routing you have plenty of options:
+
+### Option 1: Custom Route Name
 
 ```php
 'routes' => [
     'reset' => 'your.custom.route.name',
 ],
 ```
+
+### Option 2: Full URL (External System)
+
+```php
+'routes' => [
+    'reset' => 'https://external-auth.example.com/reset-password',
+],
+```
+
+### Option 3: Different Domain/Subdomain
+
+```php
+'routes' => [
+    'reset' => 'https://auth.yourapp.com/password-reset',
+],
+```
+The package automatically detects whether you're providing a route name or a full URL and handles the URL construction accordingly.
+
+### URL Base Configuration
+
+For custom routes, you can choose between using the panel's URL or the application's URL:
+
+```php
+// config/filament-invite.php
+return [
+    'routes' => [
+        'reset' => 'your.custom.route.name',
+    ],
+    
+    // URL Configuration
+    'use_panel_url' => false, // Default: false (uses app.url for backward compatibility)
+];
+```
+
+**Options:**
+1. `'use_panel_url' => false` (default): Uses `config('app.url')` - maintains backward compatibility
+2. `'use_panel_url' => true`: Uses `$panel->getUrl()`
 
 ## Customization
 

--- a/config/filament-invite.php
+++ b/config/filament-invite.php
@@ -7,4 +7,7 @@ return [
     'routes' => [
         'reset' => null,
     ],
+    
+    // URL Configuration
+    'use_panel_url' => false, // Use panel URL instead of app.url for custom routes (default: false for backward compatibility)
 ];

--- a/config/filament-invite.php
+++ b/config/filament-invite.php
@@ -5,6 +5,6 @@ return [
     'expire' => 60 * 24 * 2, // 2 days
 
     'routes' => [
-        'reset' => 'password.reset',
+        'reset' => null,
     ],
 ];

--- a/src/Actions/InviteAction.php
+++ b/src/Actions/InviteAction.php
@@ -46,7 +46,7 @@ class InviteAction extends Action
                 if (method_exists($user, 'sendPasswordSetNotification')) {
                     $user->sendPasswordSetNotification($token);
                 } elseif (method_exists($user, 'notify')) {
-                    $user->notify(new SetPassword($token, Filament::getId()));
+                    $user->notify(new SetPassword($token, Filament::getCurrentPanel()?->getId()));
                 } else {
                     Notification::send($user, new SetPassword($token, Filament::getCurrentPanel()?->getId()));
                 }

--- a/src/Actions/InviteAction.php
+++ b/src/Actions/InviteAction.php
@@ -4,10 +4,13 @@ namespace Tapp\FilamentInvite\Actions;
 
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\CanCustomizeProcess;
+use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Password;
 use Tapp\FilamentInvite\Notifications\SetPassword;
+
+use function method_exists;
 
 class InviteAction extends Action
 {
@@ -42,8 +45,10 @@ class InviteAction extends Action
                 // Use the method if the developer has specified one
                 if (method_exists($user, 'sendPasswordSetNotification')) {
                     $user->sendPasswordSetNotification($token);
+                } elseif (method_exists($user, 'notify')) {
+                    $user->notify(new SetPassword($token, Filament::getId()));
                 } else {
-                    Notification::send($user, new SetPassword($token));
+                    Notification::send($user, new SetPassword($token, Filament::getId()));
                 }
             });
 

--- a/src/Actions/InviteAction.php
+++ b/src/Actions/InviteAction.php
@@ -48,7 +48,7 @@ class InviteAction extends Action
                 } elseif (method_exists($user, 'notify')) {
                     $user->notify(new SetPassword($token, Filament::getId()));
                 } else {
-                    Notification::send($user, new SetPassword($token, Filament::getId()));
+                    Notification::send($user, new SetPassword($token, Filament::getCurrentPanel()?->getId()));
                 }
             });
 


### PR DESCRIPTION
- Use Filament default routing when config is empty
- Support custom route configuration via filament-invite.routes.reset
- Maintain backward compatibility with existing setups