### PR TITLE
Remove BladeCaptureDirectiveServiceProvider from tests

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,7 +15,6 @@ use Filament\Widgets\WidgetsServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
-use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
 use Tapp\FilamentInvite\FilamentInviteServiceProvider;
 
 class TestCase extends Orchestra
@@ -33,7 +32,6 @@ class TestCase extends Orchestra
     {
         return [
             ActionsServiceProvider::class,
-            BladeCaptureDirectiveServiceProvider::class,
             BladeHeroiconsServiceProvider::class,
             BladeIconsServiceProvider::class,
             FilamentServiceProvider::class,


### PR DESCRIPTION
## Summary
- Removes `BladeCaptureDirectiveServiceProvider` from `tests/TestCase.php`
- Filament v5 no longer depends on `ryan-chandler/blade-capture-directive`, causing all tests to fail with a class-not-found error

## Test plan
- [x] Run `./vendor/bin/pest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)