### PR TITLE
Add Laravel 13 test support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,9 +14,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.5, 8.4, 8.3]
-        laravel: [12.*, 11.*]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "larastan/larastan": "^2.9||^3.0",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0",
+        "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0",
         "pestphp/pest": "^4.0||^3.0||^2.34",
         "pestphp/pest-plugin-arch": "^4.0||^3.0||^2.7",
         "pestphp/pest-plugin-laravel": "^4.0||^3.0||^2.3",


### PR DESCRIPTION
## Summary
- allow orchestra/testbench 11 for Laravel 13 compatibility
- add Laravel 13 / Testbench 11 to the test matrix

## Local verification
- composer validate --strict --no-check-publish
- composer update --prefer-stable --prefer-dist --no-interaction --no-progress
- vendor/bin/pest --ci --no-coverage
